### PR TITLE
[docs] fix small type in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you find this implementation useful for your project, please consider citing 
 
 The conda environment used to develop this module is described by the environment.yml file. 
 ## Installation
-The out of three module gr-lora_sdr can be installed from source or directly as a conda package.
+The out of tree module gr-lora_sdr can be installed from source or directly as a conda package.
 ### From source
 - Clone this repository
 	```sh


### PR DESCRIPTION
fixes a small typo in the readme (i just read discovered the repo over [HN](https://news.ycombinator.com/item?id=37204775) nice work :+1: )